### PR TITLE
fix: resolves #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Sysco blog
 
+## Include a new author
+
+All authors are stored in the `_config.yml` file.
+A author consists out of the following properties:
+
+```yml
+name: John Doe # Name of author
+avatar: /images/avatars/johndoe.jpg # Avatar of the author
+twitter: JohnDoe # Optional Twitter of author
+```
+
 ## Local development
 
 To build and serve your site, run:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,8 @@
         </a>
         <ul>
           <li><a href="https://sysco.no/about-sysco/?lang=en" target="_blank">About</a></li>|
-          <li><a href="{{ site.baseurl }}/">Posts</a></li>
+          <li><a href="{{ site.baseurl }}/">Posts</a></li>|
+          <li><a href="{{ site.baseurl }}/posts-by-month">Posts by month</a></li>
         </ul>
       </div>
     </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
         </a>
         <ul>
           <li><a href="https://sysco.no/about-sysco/?lang=en" target="_blank">About</a></li>|
-          <li><a href="{{ site.baseurl }}/">Posts</a></li>|
+          <li><a href="{{ site.baseurl }}/">Home</a></li>|
           <li><a href="{{ site.baseurl }}/posts-by-month">Posts by month</a></li>
         </ul>
       </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -65,12 +65,14 @@ layout: default
 
 <div class="pagination">
   <ul class="inline-list">
-    {% if paginator.previous_page %}
-      <a href="{{ paginator.previous_page_path | prepend: site.baseurl }}"><li class="arrow"><i class="fas fa-angle-left"></i> Prev</li></a>
-    {% endif %}
-      <li>{{paginator.page}}</li>
-    {% if paginator.next_page %}
-      <a href="{{ paginator.next_page_path | prepend: site.baseurl }}"><li class="arrow">Next <i class="fas fa-angle-right"></i></li></a>
-    {% endif %}
+    {% for page in (1..paginator.total_pages) %}
+      {% if page == paginator.page %}
+        <li>{{ page }}</li>
+      {% elsif page == 1 %}
+        <a href="/"><li>{{ page }}</li></a>
+      {% else %}
+        <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}"><li>{{ page }}</li></a>
+      {% endif %}
+    {% endfor %}
   </ul>
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -69,7 +69,7 @@ layout: default
       {% if page == paginator.page %}
         <li>{{ page }}</li>
       {% elsif page == 1 %}
-        <a href="/"><li>{{ page }}</li></a>
+        <a href="{{ site.baseurl }}/"><li>{{ page }}</li></a>
       {% else %}
         <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}"><li>{{ page }}</li></a>
       {% endif %}

--- a/posts-by-month/index.html
+++ b/posts-by-month/index.html
@@ -1,0 +1,55 @@
+---
+layout: default
+title: All Posts
+description: "An archive of posts."
+---
+
+<div class="catalogue">
+  {% for post in site.posts  %}
+    {% capture this_year %}{{ post.date | date: "%Y" }}{% endcapture %}
+    {% capture this_month %}{{ post.date | date: "%B" }}{% endcapture %}
+    {% capture next_year %}{{ post.previous.date | date: "%Y" }}{% endcapture %}
+    {% capture next_month %}{{ post.previous.date | date: "%B" }}{% endcapture %}
+
+    {% if forloop.first %}
+    <article>
+	<h2 id="{{ this_year }}-ref">{{this_year}}</h2>
+    <h3 id="{{ this_year }}-{{ this_month }}-ref">{{ this_month }}</h3>
+    <ul>
+    {% endif %}
+
+    <li class="entry-title"><a href="{{ post.url }}">{{ post.title }}</a></li>
+
+    {% if forloop.last %}
+      </ul>
+	  </article>
+    {% else %}
+        {% if this_year != next_year %}
+        </ul>
+        <h2 id="{{ next_year }}-ref">{{next_year}}</h2>
+        <h3 id="{{ next_year }}-{{ next_month }}-ref">{{ next_month }}</h3>
+        <ul>
+        {% else %}
+            {% if this_month != next_month %}
+            </ul>
+          <h3 id="{{ this_year }}-{{ next_month }}-ref">{{ next_month }}</h3>
+            <ul>
+            {% endif %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+</div>
+
+<div class="pagination">
+  <ul class="inline-list">
+    {% for page in (1..paginator.total_pages) %}
+      {% if page == paginator.page %}
+        <li>{{ page }}</li>
+      {% elsif page == 1 %}
+        <a href="/"><li>{{ page }}</li></a>
+      {% else %}
+        <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}"><li>{{ page }}</li></a>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</div>


### PR DESCRIPTION
- [x] Why do not we have pages anymore? Clicking next and previous is quite slow.
- [x] Categorisation of posts by year/month etc.

Do we have to update the about page or should this be done on the website of Sysco?
> I have another complain about this, the about page just shows photos from Sysco, but I cannot see at least one photo from Oslo’s team.